### PR TITLE
Fix formatting of description in SKILL.md

### DIFF
--- a/skills/quality-checks/SKILL.md
+++ b/skills/quality-checks/SKILL.md
@@ -7,7 +7,7 @@ allowed-tools:
   - Bash
   - Glob
   - Grep
-description: Run code quality tools: PHP-CS-Fixer for style, PHPStan for static analysis, and type safety checks
+description: "Run code quality tools: PHP-CS-Fixer for style, PHPStan for static analysis, and type safety checks"
 ---
 
 # Quality Checks (Symfony)


### PR DESCRIPTION
fix #11

Add missing quotes to `description`.